### PR TITLE
fixe: ttl implementation

### DIFF
--- a/source/lambda/services/reporter/lib/limit-report.ts
+++ b/source/lambda/services/reporter/lib/limit-report.ts
@@ -79,7 +79,10 @@ export class LimitReport {
         usageMessage.detail["check-item-detail"]["Current Usage"] ?? "0",
       LimitAmount: usageMessage.detail["check-item-detail"]["Limit Amount"],
       Status: usageMessage.detail["status"],
-      ExpiryTime: (new Date().getTime() + 15 * 24 * 3600 * 1000).toString(), //1️⃣5️⃣ days
+      ExpiryTime: (
+          Math.round(new Date().getTime() / 1000) +
+          15 * 24 * 3600
+      ).toString(), // 1️⃣5️⃣ days from now. Unix epoch timestamp in seconds.
     };
 
     logger.debug({

--- a/source/resources/lib/hub-no-ou.stack.ts
+++ b/source/resources/lib/hub-no-ou.stack.ts
@@ -368,6 +368,7 @@ export class QuotaMonitorHubNoOU extends Stack {
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       encryption: dynamodb.TableEncryption.CUSTOMER_MANAGED,
       encryptionKey: kms.key,
+      timeToLiveAttribute: "ExpiryTime",
     });
 
     /**

--- a/source/resources/lib/hub.stack.ts
+++ b/source/resources/lib/hub.stack.ts
@@ -520,6 +520,7 @@ export class QuotaMonitorHub extends Stack {
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       encryption: dynamodb.TableEncryption.CUSTOMER_MANAGED,
       encryptionKey: kms.key,
+      timeToLiveAttribute: "ExpiryTime",
     });
 
     /**


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
`ExpiryTime` was being populated with a timestamp in milliseconds. DynamoDB requires the timestamp to be in seconds. In addition we are now setting this field as the ttl attribute on the table construct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
