### PR TITLE
change snsPublisher Lambda, add a new line to email

### DIFF
--- a/source/lambda/services/snsPublisher/index.ts
+++ b/source/lambda/services/snsPublisher/index.ts
@@ -13,7 +13,7 @@ import { SNSPublisher } from "./lib/sns-publish";
 const moduleName = <string>__filename.split("/").pop();
 
 export const handler = async (event: any) => {
-  const eventText = JSON.stringify(event);
+  const eventText = JSON.stringify(event, null, 2);
   logger.debug(`Received event: ${eventText}`);
   const ssm = new SSMHelper();
   const ssmNotificationMutingConfigParamName = <string>(


### PR DESCRIPTION
This is a very simple change.

Emails sent on Amazon SNS in the hub template are now line broken.

This is my first pull request, so please let me know if there are any mistakes.
![スクリーンショット 2024-01-18 17 06 03](https://github.com/aws-solutions/quota-monitor-for-aws/assets/65582263/b753d35d-5205-43b8-8dd8-8e8551eb6dc0)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
